### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/fastrand"
 documentation = "https://docs.rs/fastrand"
 keywords = ["simple", "fast", "rand", "random", "pcg"]
 categories = ["algorithms"]
-readme = "README.md"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = "0.1"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.