### PR TITLE
Switch to Wyrand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/fastrand"
 homepage = "https://github.com/smol-rs/fastrand"
 documentation = "https://docs.rs/fastrand"
-keywords = ["simple", "fast", "rand", "random", "pcg"]
+keywords = ["simple", "fast", "rand", "random", "wyrand"]
 categories = ["algorithms"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -21,5 +21,5 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 rand = "0.8"
-rand_pcg = "0.3"
+wyhash = "0.5.0"
 getrandom = "0.2"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ https://docs.rs/fastrand)
 
 A simple and fast random number generator.
 
-The implementation uses [PCG XSH RR 64/32][paper], a simple and fast generator but **not**
-cryptographically secure.
-
-[paper]: https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf
+The implementation uses [Wyrand](https://github.com/wangyi-fudan/wyhash), a simple and fast
+generator but **not** cryptographically secure.
 
 ## Examples
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,13 +3,13 @@
 extern crate test;
 
 use rand::prelude::*;
-use rand_pcg::Pcg32;
 use test::Bencher;
+use wyhash::WyRng;
 
 #[bench]
-fn shuffle_rand_pcg32(b: &mut Bencher) {
-    let mut rng = Pcg32::from_rng(thread_rng()).unwrap();
-    let mut x = (0..100).collect::<Vec::<usize>>();
+fn shuffle_wyhash(b: &mut Bencher) {
+    let mut rng = WyRng::from_rng(thread_rng()).unwrap();
+    let mut x = (0..100).collect::<Vec<usize>>();
     b.iter(|| {
         x.shuffle(&mut rng);
         x[0]
@@ -19,7 +19,7 @@ fn shuffle_rand_pcg32(b: &mut Bencher) {
 #[bench]
 fn shuffle_fastrand(b: &mut Bencher) {
     let rng = fastrand::Rng::new();
-    let mut x = (0..100).collect::<Vec::<usize>>();
+    let mut x = (0..100).collect::<Vec<usize>>();
     b.iter(|| {
         rng.shuffle(&mut x);
         x[0]
@@ -27,8 +27,8 @@ fn shuffle_fastrand(b: &mut Bencher) {
 }
 
 #[bench]
-fn u8_rand_pcg32(b: &mut Bencher) {
-    let mut rng = Pcg32::from_rng(thread_rng()).unwrap();
+fn u8_wyhash(b: &mut Bencher) {
+    let mut rng = WyRng::from_rng(thread_rng()).unwrap();
     b.iter(|| {
         let mut sum = 0u8;
         for _ in 0..10_000 {
@@ -51,8 +51,8 @@ fn u8_fastrand(b: &mut Bencher) {
 }
 
 #[bench]
-fn u32_rand_pcg32(b: &mut Bencher) {
-    let mut rng = Pcg32::from_rng(thread_rng()).unwrap();
+fn u32_wyhash(b: &mut Bencher) {
+    let mut rng = WyRng::from_rng(thread_rng()).unwrap();
     b.iter(|| {
         let mut sum = 0u32;
         for _ in 0..10_000 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,8 +416,7 @@ impl Rng {
     /// Initializes this generator with the given seed.
     #[inline]
     pub fn seed(&self, seed: u64) {
-        self.0.set(seed.wrapping_add(1442695040888963407));
-        self.gen_u32();
+        self.0.set(seed);
     }
 
     /// Shuffles a slice randomly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 //! A simple and fast random number generator.
 //!
-//! The implementation uses [PCG XSH RR 64/32][paper], a simple and fast generator but **not**
-//! cryptographically secure.
-//!
-//! [paper]: https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf
+//! The implementation uses [Wyrand](https://github.com/wangyi-fudan/wyhash), a simple and fast
+//! generator but **not** cryptographically secure.
 //!
 //! # Examples
 //!
@@ -122,25 +120,22 @@ impl Rng {
     /// Generates a random `u32`.
     #[inline]
     fn gen_u32(&self) -> u32 {
-        // Adapted from: https://en.wikipedia.org/wiki/Permuted_congruential_generator
-        let s = self.0.get();
-        self.0.set(
-            s.wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407),
-        );
-        (((s ^ (s >> 18)) >> 27) as u32).rotate_right((s >> 59) as u32)
+        self.gen_u64() as u32
     }
 
     /// Generates a random `u64`.
     #[inline]
     fn gen_u64(&self) -> u64 {
-        ((self.gen_u32() as u64) << 32) | (self.gen_u32() as u64)
+        let s = self.0.get().wrapping_add(0xA0761D6478BD642F);
+        self.0.set(s);
+        let t = u128::from(s) * u128::from(s ^ 0xE7037ED1A0B428DB);
+        (t as u64) ^ (t >> 64) as u64
     }
 
     /// Generates a random `u128`.
     #[inline]
     fn gen_u128(&self) -> u128 {
-        ((self.gen_u64() as u128) << 64) | (self.gen_u64() as u128)
+        (u128::from(self.gen_u64()) << 64) | u128::from(self.gen_u64())
     }
 
     /// Generates a random `u32` in `0..n`.


### PR DESCRIPTION
Wyrand is faster than PCG and also passes all of the tests.

PCG benchmarks:
```
test shuffle_fastrand   ... bench:         405 ns/iter (+/- 9)
test u32_fastrand       ... bench:      13,779 ns/iter (+/- 657)
test u8_fastrand        ... bench:      13,771 ns/iter (+/- 696)
```
Wyrand benchmarks:
```
test shuffle_fastrand ... bench:         225 ns/iter (+/- 2)
test u32_fastrand     ... bench:      11,464 ns/iter (+/- 317)
test u8_fastrand      ... bench:      12,402 ns/iter (+/- 304)
```

Closes #19 