### PR TITLE
Add choose_multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ let i = fastrand::usize(..v.len());
 let elem = v[i];
 ```
 
+Sample values from an array with `O(n)` complexity (`n` is the length of array):
+
+```rust
+fastrand::choose_multiple(vec![1, 4, 5].iter(), 2);
+fastrand::choose_multiple(0..20, 12);
+```
+
 Shuffle an array:
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,7 @@ impl Rng {
     /// elements available.
     ///
     /// Complexity is `O(n)` where `n` is the length of the iterator.
-    pub fn choose_multiple<T: std::iter::Iterator + Sized>(
+    pub fn choose_multiple<T: std::iter::Iterator>(
         &self,
         mut source: T,
         amount: usize,
@@ -713,6 +713,6 @@ pub fn f64() -> f64 {
 }
 
 /// Collects `amount` values at random from the iterator into a vector.
-pub fn choose_multiple<T: std::iter::Iterator + Sized>(source: T, amount: usize) -> Vec<T::Item> {
+pub fn choose_multiple<T: std::iter::Iterator>(source: T, amount: usize) -> Vec<T::Item> {
     RNG.with(|rng| rng.choose_multiple(source, amount))
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -115,3 +115,12 @@ fn with_seed() {
     b.seed(7);
     assert_eq!(a.u64(..), b.u64(..));
 }
+
+#[test]
+fn choose_multiple() {
+    let a = fastrand::Rng::with_seed(7);
+    assert_eq!(
+        a.choose_multiple(0..20, 12),
+        vec![0, 1, 17, 15, 4, 14, 6, 7, 19, 9, 18, 13]
+    );
+}


### PR DESCRIPTION
The `choose_multiple` function chooses multiple elements from an iterable, using the reservoir sampling algorithm. It is useful for sampling numbers from a list and generating a list of random numbers with no repetition. 

Adapted from: https://docs.rs/rand/latest/rand/seq/trait.IteratorRandom.html#method.choose_multiple.