### PR TITLE
Implement RngCore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 wasm-bindgen-test = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 
+[dependencies]
+rand_core = "0.6"
+
 [dev-dependencies]
 rand = "0.8"
 wyhash = "0.5"
 getrandom = "0.2"
+rand_core = "0.6"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A simple and fast random number generator.
 The implementation uses [Wyrand](https://github.com/wangyi-fudan/wyhash), a simple and fast
 generator but **not** cryptographically secure.
 
+It implements the trait `rand::Rng` so it should work in most libraries that accept an random number generator. 
+
 ## Examples
 
 Flip a coin:

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,3 +1,4 @@
+use rand::prelude::IteratorRandom;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
@@ -114,4 +115,17 @@ fn with_seed() {
     let b = fastrand::Rng::new();
     b.seed(7);
     assert_eq!(a.u64(..), b.u64(..));
+}
+
+#[test]
+fn rand_core() {
+    let mut a = fastrand::Rng::with_seed(7);
+    assert_eq!(
+        "abcde"
+            .chars()
+            .choose_multiple(&mut a, 2)
+            .into_iter()
+            .collect::<String>(),
+        "ad"
+    );
 }


### PR DESCRIPTION
Some libraries such as `statrs` accepts random number generators that implement the `rand::Rng` trait. This PR implements that trait (by implementing `rand_core::RngCore`). This will make it more useful to be integrated into other projects.