### PR TITLE
Optimise .fill() throughput

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,17 +444,24 @@ impl Rng {
 
     /// Fill a byte slice with random data.
     pub fn fill(&self, slice: &mut [u8]) {
-        // Filling the buffer in chunks of 8 is much faster.
-        let mut chunks = slice.chunks_exact_mut(8);
+        // We fill the slice by chunks of 8 bytes, or one block of
+        // WyRand output per new state.
+        let mut chunks = slice.chunks_exact_mut(core::mem::size_of::<u64>());
         for chunk in chunks.by_ref() {
-            let n = self.gen_u64();
+            let n = self.gen_u64().to_ne_bytes();
             // Safe because the chunks are always 8 bytes exactly.
-            let bytes: &mut [u8; 8] = chunk.try_into().unwrap();
-            *bytes = n.to_ne_bytes();
+            chunk.copy_from_slice(&n);
         }
 
-        for item in chunks.into_remainder() {
-            *item = self.u8(..);
+        let remainder = chunks.into_remainder();
+
+        // Any remainder will always be less than 8 bytes.
+        if !remainder.is_empty() {
+            // Generate one last block of 8 bytes of entropy
+            let n = self.gen_u64().to_ne_bytes();
+
+            // Use the remaining length to copy from block
+            remainder.copy_from_slice(&n[..remainder.len()]);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,6 +443,7 @@ impl Rng {
     }
 
     /// Fill a byte slice with random data.
+    #[inline]
     pub fn fill(&self, slice: &mut [u8]) {
         // We fill the slice by chunks of 8 bytes, or one block of
         // WyRand output per new state.


### PR DESCRIPTION
Looking at the fill method, I noticed there was some room for optimisation, and also removing unnecessary `unwrap()` from the hot loop. Also, the remainder portion was generating new entropy blocks for every `u8` portion, when any remaining slice length would always be less than 8 bytes, or one `u64` block (which is what `WyRand` generates per new state), Therefore, a maximum of seven `u8` calls can be reduced to just one `u64` block.

Afterwards, I simplified the copying of entropy to make use of `copy_from_slice`, since we know that either the slices will match (and need no `try_into` conversions), or that the length of the input will always be smaller than the target.

I then benchmarked the resulting code, on my AMD Ryzen 5 Pro 2500U (4C/8T 2,0Ghz base, 3.6Ghz max) with 16GB RAM.

Before:
```
running 2 tests
test fill             ... bench:          68 ns/iter (+/- 1)
test fill_naive       ... bench:         471 ns/iter (+/- 9)
```

After:
```
running 2 tests
test fill             ... bench:          64 ns/iter (+/- 1)
test fill_naive       ... bench:         485 ns/iter (+/- 15)
```

I was getting 68-70ns before, and now 64-65ns afterwards. Now, I added the `#[inline]` annotation out of curiosity and tested it, and was getting even more perf as a result:

After with `#[inline]`
```
running 2 tests
test fill             ... bench:          56 ns/iter (+/- 1)
test fill_naive       ... bench:         472 ns/iter (+/- 14)
```

So it might be advantageous to include it. So end result with all changes here is we've gone from 68-70ns to 64-65ns to then 56ns.