### PR TITLE
Remove interior mutability from Rng

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,7 +18,7 @@ fn shuffle_wyhash(b: &mut Bencher) {
 
 #[bench]
 fn shuffle_fastrand(b: &mut Bencher) {
-    let rng = fastrand::Rng::new();
+    let mut rng = fastrand::Rng::new();
     let mut x = (0..100).collect::<Vec<usize>>();
     b.iter(|| {
         rng.shuffle(&mut x);
@@ -40,7 +40,7 @@ fn u8_wyhash(b: &mut Bencher) {
 
 #[bench]
 fn u8_fastrand(b: &mut Bencher) {
-    let rng = fastrand::Rng::new();
+    let mut rng = fastrand::Rng::new();
     b.iter(|| {
         let mut sum = 0u8;
         for _ in 0..10_000 {
@@ -64,7 +64,7 @@ fn u32_wyhash(b: &mut Bencher) {
 
 #[bench]
 fn u32_fastrand(b: &mut Bencher) {
-    let rng = fastrand::Rng::new();
+    let mut rng = fastrand::Rng::new();
     b.iter(|| {
         let mut sum = 0u32;
         for _ in 0..10_000 {
@@ -76,7 +76,7 @@ fn u32_fastrand(b: &mut Bencher) {
 
 #[bench]
 fn fill(b: &mut Bencher) {
-    let rng = fastrand::Rng::new();
+    let mut rng = fastrand::Rng::new();
     b.iter(|| {
         // Pick a size that isn't divisble by 8.
         let mut bytes = [0u8; 367];
@@ -87,7 +87,7 @@ fn fill(b: &mut Bencher) {
 
 #[bench]
 fn fill_naive(b: &mut Bencher) {
-    let rng = fastrand::Rng::new();
+    let mut rng = fastrand::Rng::new();
     b.iter(|| {
         let mut bytes = [0u8; 367];
         for item in &mut bytes {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -77,7 +77,7 @@ fn u128() {
 
 #[test]
 fn fill() {
-    let r = fastrand::Rng::new();
+    let mut r = fastrand::Rng::new();
     let mut a = [0u8; 64];
     let mut b = [0u8; 64];
 
@@ -89,7 +89,7 @@ fn fill() {
 
 #[test]
 fn rng() {
-    let r = fastrand::Rng::new();
+    let mut r = fastrand::Rng::new();
 
     assert_ne!(r.u64(..), r.u64(..));
 
@@ -102,8 +102,8 @@ fn rng() {
 
 #[test]
 fn rng_init() {
-    let a = fastrand::Rng::new();
-    let b = fastrand::Rng::new();
+    let mut a = fastrand::Rng::new();
+    let mut b = fastrand::Rng::new();
     assert_ne!(a.u64(..), b.u64(..));
 
     a.seed(7);
@@ -113,8 +113,8 @@ fn rng_init() {
 
 #[test]
 fn with_seed() {
-    let a = fastrand::Rng::with_seed(7);
-    let b = fastrand::Rng::new();
+    let mut a = fastrand::Rng::with_seed(7);
+    let mut b = fastrand::Rng::new();
     b.seed(7);
     assert_eq!(a.u64(..), b.u64(..));
 }


### PR DESCRIPTION
This PR removes interior mutability from the `Rng` type by removing the `Cell` from inside of it and making all of its methods take `&mut`. This closes #31, and also helps with #36 as a side effect, since we can't call `u64()` anymore from `&self`.

This is a breaking change, but resolving most of our current issues would require a breaking change as well.

Closes #26 
Closes #38