### PR TITLE
Touch up PR 50

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install Rust
         # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
         run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      - run: rustup target add thumbv7m-none-eabi
       - name: Install wasm-pack
         uses: taiki-e/install-action@wasm-pack
         if: startsWith(matrix.os, 'ubuntu')
@@ -49,7 +50,8 @@ jobs:
         run: cargo check -Z features=dev_dep
       - run: cargo test
       - name: Build with no default features
-        run: cargo build --no-default-features
+        # Use no-std target to ensure we don't link to std.
+        run: cargo build --no-default-features --target thumbv7m-none-eabi
       - name: Test wasm
         run: wasm-pack test --headless --chrome
         if: startsWith(matrix.os, 'ubuntu')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ exclude = ["/.*"]
 
 [features]
 default = ["std"]
-std = []
+std = ["instant"]
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
-instant = "0.1"
+instant = { version = "0.1", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }


### PR DESCRIPTION
- Disable dependency on instant when std feature is disabled
- Fix no-std check
  Use no-std target to ensure we don't link to std.
