### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version 2.0.0
+
+- **Breaking:** Remove interior mutability from `Rng`. (#47)
+- Add a `fork()` method. (#49)
+- Add a `no_std` mode. (#50)
+- Add an iterator selection function. (#51)
+- Add a `choose_multiple()` function for sampling several elements from an iterator. (#55)
+- Use the `getrandom` crate for seeding on WebAssembly targets if the `js` feature is enabled. (#60)
+
 # Version 1.9.0
 
 - Add `Rng::fill()` (#35, #43)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "fastrand"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v1.x.y" git tag
-version = "1.9.0"
+# - Create "v2.x.y" git tag
+version = "2.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.36"


### PR DESCRIPTION
- **Breaking:** Remove interior mutability from `Rng`. (#47)
- Add a `fork()` method. (#49)
- Add a `no_std` mode. (#50)
- Add an iterator selection function. (#51)
- Add a `choose_multiple()` function for sampling several elements from an iterator. (#55)
- Use the `getrandom` crate for seeding on WebAssembly targets if the `js` feature is enabled. (#60)