### PR TITLE
Use getrandom for seeding the RNG on WASM targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,10 @@ exclude = ["/.*"]
 default = ["std"]
 alloc = []
 std = ["alloc"]
+js = ["std", "getrandom"]
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.web-sys]
-version = "0.3.62"
-features = [
-    "Window",
-    "Crypto"
-]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+getrandom = { version = "0.2", features = ["js"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ alloc = []
 std = ["alloc"]
 js = ["std", "getrandom"]
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"], optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,16 @@ exclude = ["/.*"]
 [features]
 default = ["std"]
 alloc = []
-std = ["alloc", "instant"]
+std = ["alloc"]
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
-instant = { version = "0.1", optional = true }
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies.web-sys]
+version = "0.3.62"
+features = [
+    "Window",
+    "Crypto"
+]
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
-instant = { version = "0.1", features = ["wasm-bindgen"] }
 wasm-bindgen-test = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -179,7 +179,10 @@ pub fn choose_multiple<T: Iterator>(source: T, amount: usize) -> Vec<T::Item> {
     with_rng(|rng| rng.choose_multiple(source, amount))
 }
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    target_os = "unknown"
+)))]
 fn random_seed() -> Option<u64> {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -193,7 +196,11 @@ fn random_seed() -> Option<u64> {
     Some((hash << 1) | 1)
 }
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "js"))]
+#[cfg(all(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    target_os = "unknown",
+    feature = "js"
+))]
 fn random_seed() -> Option<u64> {
     // TODO(notgull): Failures should be logged somewhere.
     let mut seed = [0u8; 8];
@@ -201,7 +208,11 @@ fn random_seed() -> Option<u64> {
     Some(u64::from_ne_bytes(seed))
 }
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(feature = "js")))]
+#[cfg(all(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    target_os = "unknown",
+    not(feature = "js")
+))]
 fn random_seed() -> Option<u64> {
     None
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //! environment. At this point, the [`getrandom`] crate will be used in order to access the available
 //! entropy sources and seed the global RNG. If the `js` feature is not enabled, the global RNG will
 //! use a predefined seed.
-//! 
+//!
 //! [`getrandom`]: https://crates.io/crates/getrandom
 
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,19 @@
 //! - `std` (enabled by default): Enables the `std` library. This is required for the global
 //!   generator and global entropy. Without this feature, [`Rng`] can only be instantiated using
 //!   the [`with_seed`](Rng::with_seed) method.
+//! - `js`: Assumes that WebAssembly targets are being run in a JavaScript environment. See the
+//!   [WebAssembly Notes](#webassembly-notes) section for more information.
+//!
+//! # WebAssembly Notes
+//!
+//! For non-WASI WASM targets, there is additional sublety to consider when utilizing the global RNG.
+//! By default, `std` targets will use entropy sources in the standard library to seed the global RNG.
+//! However, these sources are not available by default on WASM targets outside of WASI.
+//!
+//! If the `js` feature is enabled, this crate will assume that it is running in a JavaScript
+//! environment. At this point, the [`getrandom`] crate will be used in order to access the available
+//! entropy sources and seed the global RNG. If the `js` feature is not enabled, the global RNG will
+//! use a predefined seed.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@
 //! environment. At this point, the [`getrandom`] crate will be used in order to access the available
 //! entropy sources and seed the global RNG. If the `js` feature is not enabled, the global RNG will
 //! use a predefined seed.
+//! 
+//! [`getrandom`]: https://crates.io/crates/getrandom
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
See [this comment](https://github.com/smol-rs/fastrand/pull/59#issuecomment-1546589997). On Web targets with the `js` feature enabled, the `getrandom` crate is used to seed the global RNG. When it isn't, it just uses a fixed seed.

Closes #27
Closes #54
