### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.0.1
+
+- Clarify documentation for the `fork()` method. (#62)
+- Mention `fastrand-contrib` in documentation. (#70)
+
 # Version 2.0.0
 
 - **Breaking:** Remove interior mutability from `Rng`. (#47)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fastrand"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.36"


### PR DESCRIPTION
- Clarify documentation for the `fork()` method. (#62)
- Mention `fastrand-contrib` in documentation. (#70)