### PR TITLE
Remove unnecessary seed modifcation

### DIFF
--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -192,8 +192,7 @@ fn random_seed() -> Option<u64> {
     let mut hasher = DefaultHasher::new();
     Instant::now().hash(&mut hasher);
     thread::current().id().hash(&mut hasher);
-    let hash = hasher.finish();
-    Some((hash << 1) | 1)
+    Some(hasher.finish())
 }
 
 #[cfg(all(


### PR DESCRIPTION
Because the first step of wyrand is an addition with a constant, a non-zero seed is not required