### PR TITLE
Remove try_with_rng

### DIFF
--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -23,7 +23,7 @@ impl Rng {
     /// Creates a new random number generator.
     #[inline]
     pub fn new() -> Rng {
-        try_with_rng(Rng::fork).unwrap_or_else(|_| Rng::with_seed(0x4d595df4d0f33173))
+        with_rng(Rng::fork)
     }
 }
 
@@ -35,18 +35,6 @@ std::thread_local! {
 #[inline]
 fn with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> R {
     RNG.with(|rng| {
-        let current = rng.replace(Rng(0));
-
-        let mut restore = RestoreOnDrop { rng, current };
-
-        f(&mut restore.current)
-    })
-}
-
-/// Try to run an operation with the current thread-local generator.
-#[inline]
-fn try_with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> Result<R, std::thread::AccessError> {
-    RNG.try_with(|rng| {
         let current = rng.replace(Rng(0));
 
         let mut restore = RestoreOnDrop { rng, current };


### PR DESCRIPTION
The local function `try_with_rng` in global_rng can be removed, because it is not possible to access the thread local storage `RNG` twice with given functions.

Based on my understanding of the code, this would require any given function to access `RNG` while `RNG` is in use. Since this would affect every other `with_rng` call as well, this seems not possible.

The `try_with` usage exists since initial commit. My idea of this PR is to simplify the code for reviewers, because it took quite some time for me to figure out that this fixed seed usage is never reached.

At least if I'm correct. It would be great if someone could review. 