### PR TITLE
Always set #![no_std] to fix redundant import warning

### DIFF
--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -4,6 +4,7 @@ use crate::Rng;
 
 use std::cell::Cell;
 use std::ops::RangeBounds;
+use std::vec::Vec;
 
 // Chosen by fair roll of the dice.
 const DEFAULT_RNG_SEED: u64 = 0xef6f79ed30ba75a;
@@ -26,7 +27,7 @@ impl Rng {
     }
 }
 
-thread_local! {
+std::thread_local! {
     static RNG: Cell<Rng> = Cell::new(Rng(random_seed().unwrap_or(DEFAULT_RNG_SEED)));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 //! [`fastrand-contrib`]: https://crates.io/crates/fastrand-contrib
 //! [`getrandom`]: https://crates.io/crates/getrandom
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
@@ -111,6 +111,8 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 use core::convert::{TryFrom, TryInto};
 use core::ops::{Bound, RangeBounds};


### PR DESCRIPTION
```
error: the item `Vec` is imported redundantly
   --> src/lib.rs:119:5
    |
119 | use alloc::vec::Vec;
    |     ^^^^^^^^^^^^^^^
   --> /rustc/5119208fd78a77547c705d1695428c88d6791263/library/std/src/prelude/mod.rs:115:13
    |
    = note: the item `Vec` is already defined here
    |
    = note: `-D unused-imports` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_imports)]`
```