### PR TITLE
Use wyrand final v4.2 constants for gen_u64()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,9 +148,14 @@ impl Rng {
     /// Generates a random `u64`.
     #[inline]
     fn gen_u64(&mut self) -> u64 {
-        let s = self.0.wrapping_add(0xA0761D6478BD642F);
+        // Constants for WyRand taken from: https://github.com/wangyi-fudan/wyhash/blob/master/wyhash.h#L151
+        // Updated for the final v4.2 implementation with improved constants for better entropy output.
+        const WY_CONST_0: u64 = 0x2d35_8dcc_aa6c_78a5;
+        const WY_CONST_1: u64 = 0x8bb8_4b93_962e_acc9;
+
+        let s = self.0.wrapping_add(WY_CONST_0);
         self.0 = s;
-        let t = u128::from(s) * u128::from(s ^ 0xE7037ED1A0B428DB);
+        let t = u128::from(s) * u128::from(s ^ WY_CONST_1);
         (t as u64) ^ (t >> 64) as u64
     }
 


### PR DESCRIPTION
**BREAKING CHANGE**

This PR introduces updates to `fastrand`'s Wyrand algorithm, primarily using updated constants from the final v4.2 implementation of `wyhash`. This modification of the constants means the output of the generator is different, hence the breaking change. Based on the C reference, the new constants are generated using the same secrets algorithm but with a modification to ensure the constants are also large prime numbers. This additional property has helped improve the quality of the hashing for wyhash and the reference `wyrand` function.

Given the wide usage of `fastrand`, improving the quality of the generated output will be a nice plus, especially if it does not involve any performance hits (since `fastrand` is about being *fast*). But it will necessitate a new major version as anyone relying on deterministic output will have different generated sequences compared to before.

Reference:
[C reference `wyrand` function](https://github.com/wangyi-fudan/wyhash/blob/master/wyhash.h#L151)