### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 2.1.0
+
+- Change the RNG algorithm and the way that the seed is computed. This will cause
+  the algorithm to emit different constants for different seeds, hence the minor
+  SemVer change.
+  - Update to the final WyRand v4.2 constants for better entropy. (#82)
+  - Remove an unnecessary seed modification. (#73)
+
 # Version 2.0.2
 
 - Slight restructuring of the `with_seed` function. (#79)


### PR DESCRIPTION
- Change the RNG algorithm and the way that the seed is computed. This will cause
  the algorithm to emit different constants for different seeds, hence the minor
  SemVer change.
  - Update to the final WyRand v4.2 constants for better entropy. (#82)
  - Remove an unnecessary seed modification. (#73)
