### PR TITLE
Always use getrandom to seed RNG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ exclude = ["/.*"]
 default = ["std"]
 alloc = []
 std = ["alloc"]
-js = ["std", "getrandom"]
+js = ["std", "getrandom/js"]
 
-[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", features = ["js"], optional = true }
+[dependencies]
+getrandom = "0.2"
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -182,25 +182,9 @@ pub fn choose_multiple<T: Iterator>(source: T, amount: usize) -> Vec<T::Item> {
 
 #[cfg(not(all(
     any(target_arch = "wasm32", target_arch = "wasm64"),
-    target_os = "unknown"
-)))]
-fn random_seed() -> Option<u64> {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    use std::thread;
-    use std::time::Instant;
-
-    let mut hasher = DefaultHasher::new();
-    Instant::now().hash(&mut hasher);
-    thread::current().id().hash(&mut hasher);
-    Some(hasher.finish())
-}
-
-#[cfg(all(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
     target_os = "unknown",
-    feature = "js"
-))]
+    not(feature = "js")
+)))]
 fn random_seed() -> Option<u64> {
     // TODO(notgull): Failures should be logged somewhere.
     let mut seed = [0u8; 8];


### PR DESCRIPTION
This PR makes the default random RNG seed always use `getrandom`.
The original code looked like this:
```rust
fn random_seed() -> Option<u64> {
    use std::collections::hash_map::DefaultHasher;
    use std::hash::{Hash, Hasher};
    use std::thread;
    use std::time::Instant;

    let mut hasher = DefaultHasher::new();
    Instant::now().hash(&mut hasher);
    thread::current().id().hash(&mut hasher);
    Some(hasher.finish())
}
```
`DefaultHasher` doesn't actually have any randomness in it, so you're just hashing the current time and thread ID to seed RNG.
This works, but it seemed wrong to me when I saw it. There's an implementation with `getrandom` right there.

A few other things I noticed:
The `#[cfg(target_pointer_width = "128")]` at `lib.rs` line `622` is generating a warning, which has been failing CI since May, after the `unexpected_cfgs` lint was added in Rust 1.80.
Unrelated but I also really like the cat logo.