### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.1.1
+
+- Remove support for 128-bit targets, as they are not supported by rustc yet. (#87)
+
 # Version 2.1.0
 
 - Change the RNG algorithm and the way that the seed is computed. This will cause

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fastrand"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.36"


### PR DESCRIPTION
- Remove support for 128-bit targets, as they are not supported by rustc yet. (#87)
