### PR TITLE
Expose missing fill method in global_rng module

### DIFF
--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -139,6 +139,12 @@ pub fn shuffle<T>(slice: &mut [T]) {
     with_rng(|r| r.shuffle(slice))
 }
 
+/// Fill a byte slice with random data.
+#[inline]
+pub fn fill(slice: &mut [u8]) {
+    with_rng(|r| r.fill(slice))
+}
+
 macro_rules! integer {
     ($t:tt, $doc:tt) => {
         #[doc = $doc]


### PR DESCRIPTION
I recently had a use case for `Rng::fill`, but had to instantiate a new Rng because the method isn't exposed from the crate's global one. All the other Rng methods are present in `mod global_rng`, so I figured it's an oversight.