### PR TITLE
v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.3.0
+
+- Accept `IntoIterator` in `choose_multiple` functions instead of just `Iterator`. (#92)
+
 # Version 2.2.0
 
 - Expose missing `fill` method for the global RNG. (#90)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fastrand"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.36"


### PR DESCRIPTION
- Accept `IntoIterator` in `choose_multiple` functions instead of just `Iterator`. (#92)
