### PR TITLE
Bump resolver to version 2 to fix web CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/smol-rs/fastrand"
 keywords = ["simple", "fast", "rand", "random", "wyrand"]
 categories = ["algorithms"]
 exclude = ["/.*"]
+resolver = "2"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This fixes the wasm-bindgen-test errors in CI.
