### PR TITLE
Revert "Bump resolver to version 2 to fix web CI"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/smol-rs/fastrand"
 keywords = ["simple", "fast", "rand", "random", "wyrand"]
 categories = ["algorithms"]
 exclude = ["/.*"]
-resolver = "2"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Reverts smol-rs/fastrand#96

See https://github.com/smol-rs/fastrand/pull/95#issuecomment-2524799476