### PR TITLE
ci: Use reusable workflows for fmt and security_audit & fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -92,27 +102,3 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - run: cargo clippy --all-features --tests --examples
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
         run: rustup update stable
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
-          target: wasm32-wasi
-      - run: cargo test --target wasm32-wasi
+          target: wasm32-wasip1
+      - run: cargo test --target wasm32-wasip1
 
   msrv:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/1 for details about reusable workflows.
See https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html for details about the second commit.
