### PR TITLE
Improve quality of f32/f64 generation.

### DIFF
--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -176,9 +176,19 @@ pub fn f32() -> f32 {
     with_rng(|r| r.f32())
 }
 
+/// Generates a random `f32` in range `0..=1`.
+pub fn f32_inclusive() -> f32 {
+    with_rng(|r| r.f32_inclusive())
+}
+
 /// Generates a random `f64` in range `0..1`.
 pub fn f64() -> f64 {
     with_rng(|r| r.f64())
+}
+
+/// Generates a random `f64` in range `0..=1`.
+pub fn f64_inclusive() -> f64 {
+    with_rng(|r| r.f64_inclusive())
 }
 
 /// Collects `amount` values at random from the iterable into a vector.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,7 @@ impl Rng {
         // See e.g. Section 3.1 of Thomas, David B., et al. "Gaussian random number generators,
         // https://www.doc.ic.ac.uk/~wl/papers/07/csur07dt.pdf, for background.
         const MUL: f32 = 1.0 / (1u64 << 63) as f32;
-        (self.u64(..) >> 1) as f32 * MUL
+        (self.gen_u64() >> 1) as f32 * MUL
     }
 
     /// Generates a random `f32` in range `0..1`.
@@ -410,7 +410,7 @@ impl Rng {
     pub fn f64_inclusive(&mut self) -> f64 {
         // See the comment in f32_inclusive() for more details.
         const MUL: f64 = 1.0 / (1u64 << 63) as f64;
-        (self.u64(..) >> 1) as f64 * MUL
+        (self.gen_u64() >> 1) as f64 * MUL
     }
 
     /// Generates a random `f64` in range `0..1`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,7 @@ impl Rng {
     }
 
     /// Generates a random `f32` in range `0..=1`.
+    #[inline]
     pub fn f32_inclusive(&mut self) -> f32 {
         // Generate a number in 0..2^63 then convert to f32 and multiply by 2^(-63).
         //
@@ -394,6 +395,7 @@ impl Rng {
     ///
     /// Function `f32_inclusive()` is a little simpler and faster, so default
     /// to that if inclusive range is acceptable.
+    #[inline]
     pub fn f32(&mut self) -> f32 {
         loop {
             let x = self.f32_inclusive();
@@ -404,6 +406,7 @@ impl Rng {
     }
 
     /// Generates a random `f64` in range `0..=1`.
+    #[inline]
     pub fn f64_inclusive(&mut self) -> f64 {
         // See the comment in f32_inclusive() for more details.
         const MUL: f64 = 1.0 / (1u64 << 63) as f64;
@@ -414,6 +417,7 @@ impl Rng {
     ///
     /// Function `f64_inclusive()` is a little simpler and faster, so default
     /// to that if inclusive range is acceptable.
+    #[inline]
     pub fn f64(&mut self) -> f64 {
         loop {
             let x = self.f64_inclusive();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,10 +383,16 @@ impl Rng {
         // is no larger than the bias in the underlying WyRand generator: since it only
         // has a 64-bit state, it necessarily already have biases of at least 2^(-64)
         // probability.
+        //
+        // See e.g. Section 3.1 of Thomas, David B., et al. "Gaussian random number generators,
+        // https://www.doc.ic.ac.uk/~wl/papers/07/csur07dt.pdf, for background.
         (self.u64(..) >> 1) as f32 * (-63.0f32).exp2()
     }
 
     /// Generates a random `f32` in range `0..1`.
+    /// 
+    /// Function `f32_inclusive()` is a little simpler and faster, so default
+    /// to that if inclusive range is acceptable.
     pub fn f32(&mut self) -> f32 {
         loop {
             let x = self.f32_inclusive();
@@ -403,6 +409,9 @@ impl Rng {
     }
 
     /// Generates a random `f64` in range `0..1`.
+    /// 
+    /// Function `f64_inclusive()` is a little simpler and faster, so default
+    /// to that if inclusive range is acceptable.
     pub fn f64(&mut self) -> f64 {
         loop {
             let x = self.f64_inclusive();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,8 @@ impl Rng {
         //
         // See e.g. Section 3.1 of Thomas, David B., et al. "Gaussian random number generators,
         // https://www.doc.ic.ac.uk/~wl/papers/07/csur07dt.pdf, for background.
-        (self.u64(..) >> 1) as f32 * (-63.0f32).exp2()
+        const MUL: f32 = 1.0 / (1u64 << 63) as f32;
+        (self.u64(..) >> 1) as f32 * MUL
     }
 
     /// Generates a random `f32` in range `0..1`.
@@ -405,7 +406,8 @@ impl Rng {
     /// Generates a random `f64` in range `0..=1`.
     pub fn f64_inclusive(&mut self) -> f64 {
         // See the comment in f32_inclusive() for more details.
-        (self.u64(..) >> 1) as f64 * (-63.0f64).exp2()
+        const MUL: f64 = 1.0 / (1u64 << 63) as f64;
+        (self.u64(..) >> 1) as f64 * MUL
     }
 
     /// Generates a random `f64` in range `0..1`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl Rng {
     }
 
     /// Generates a random `f32` in range `0..1`.
-    /// 
+    ///
     /// Function `f32_inclusive()` is a little simpler and faster, so default
     /// to that if inclusive range is acceptable.
     pub fn f32(&mut self) -> f32 {
@@ -402,14 +402,14 @@ impl Rng {
         }
     }
 
-   /// Generates a random `f64` in range `0..=1`.
+    /// Generates a random `f64` in range `0..=1`.
     pub fn f64_inclusive(&mut self) -> f64 {
         // See the comment in f32_inclusive() for more details.
         (self.u64(..) >> 1) as f64 * (-63.0f64).exp2()
     }
 
     /// Generates a random `f64` in range `0..1`.
-    /// 
+    ///
     /// Function `f64_inclusive()` is a little simpler and faster, so default
     /// to that if inclusive range is acceptable.
     pub fn f64(&mut self) -> f64 {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -95,12 +95,49 @@ fn f32() {
 }
 
 #[test]
+fn f32_inclusive() {
+    let mut r = fastrand::Rng::with_seed(0);
+    let tiny = (-24.0f32).exp2();
+    let mut count_top_half = 0;
+    let mut count_tiny_nonzero = 0;
+    let mut count_one = 0;
+    for _ in 0..100_000_000 {
+        let x = r.f32_inclusive();
+        assert!(x >= 0.0 && x <= 1.0);
+        if x == 1.0 {
+            count_one += 1;
+        } else if x > 0.5 {
+            count_top_half += 1;
+        } else if x > 0.0 && x < tiny {
+            count_tiny_nonzero += 1;
+        }
+    }
+    assert!(count_top_half >= 49_000_000);
+    assert!(count_one > 0);
+    assert!(count_tiny_nonzero > 0);
+}
+
+#[test]
 fn f64() {
     let mut r = fastrand::Rng::with_seed(0);
     let mut count_top_half = 0;
     for _ in 0..100_000_000 {
         let x = r.f64();
         assert!(x >= 0.0 && x < 1.0);
+        if x > 0.5 {
+            count_top_half += 1;
+        }
+    }
+    assert!(count_top_half >= 49_000_000);
+}
+
+#[test]
+fn f64_inclusive() {
+    let mut r = fastrand::Rng::with_seed(0);
+    let mut count_top_half = 0;
+    for _ in 0..100_000_000 {
+        let x = r.f64();
+        assert!(x >= 0.0 && x <= 1.0);
         if x > 0.5 {
             count_top_half += 1;
         }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -76,6 +76,39 @@ fn u128() {
 }
 
 #[test]
+fn f32() {
+    let mut r = fastrand::Rng::with_seed(0);
+    let tiny = (-24.0f32).exp2();
+    let mut count_tiny_nonzero = 0;
+    let mut count_top_half = 0;
+    for _ in 0..100_000_000 {
+        let x = r.f32();
+        assert!(x >= 0.0 && x < 1.0);
+        if x > 0.0 && x < tiny {
+            count_tiny_nonzero += 1;
+        } else if x > 0.5 {
+            count_top_half += 1;
+        }
+    }
+    assert!(count_top_half >= 49_000_000);
+    assert!(count_tiny_nonzero > 0);
+}
+
+#[test]
+fn f64() {
+    let mut r = fastrand::Rng::with_seed(0);
+    let mut count_top_half = 0;
+    for _ in 0..100_000_000 {
+        let x = r.f64();
+        assert!(x >= 0.0 && x < 1.0);
+        if x > 0.5 {
+            count_top_half += 1;
+        }
+    }
+    assert!(count_top_half >= 49_000_000);
+}
+
+#[test]
 fn fill() {
     let mut r = fastrand::Rng::new();
     let mut a = [0u8; 64];

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -83,7 +83,7 @@ fn f32() {
     let mut count_top_half = 0;
     for _ in 0..100_000_000 {
         let x = r.f32();
-        assert!(x >= 0.0 && x < 1.0);
+        assert!((0.0..1.0).contains(&x));
         if x > 0.0 && x < tiny {
             count_tiny_nonzero += 1;
         } else if x > 0.5 {
@@ -103,7 +103,7 @@ fn f32_inclusive() {
     let mut count_one = 0;
     for _ in 0..100_000_000 {
         let x = r.f32_inclusive();
-        assert!(x >= 0.0 && x <= 1.0);
+        assert!((0.0..=1.0).contains(&x));
         if x == 1.0 {
             count_one += 1;
         } else if x > 0.5 {
@@ -123,7 +123,7 @@ fn f64() {
     let mut count_top_half = 0;
     for _ in 0..100_000_000 {
         let x = r.f64();
-        assert!(x >= 0.0 && x < 1.0);
+        assert!((0.0..1.0).contains(&x));
         if x > 0.5 {
             count_top_half += 1;
         }
@@ -136,8 +136,8 @@ fn f64_inclusive() {
     let mut r = fastrand::Rng::with_seed(0);
     let mut count_top_half = 0;
     for _ in 0..100_000_000 {
-        let x = r.f64();
-        assert!(x >= 0.0 && x <= 1.0);
+        let x = r.f64_inclusive();
+        assert!((0.0..=1.0).contains(&x));
         if x > 0.5 {
             count_top_half += 1;
         }


### PR DESCRIPTION
The previous int-to-float conversion had a bias of probability 2^-24 / 2^-53 for types f32 / f64 respectively. The new conversion has a bias of 2^-64, which is the same bias as the underlying WyRand generator. See comments in `lib.rs` for explanation.

The new conversion is a slightly shorter instruction sequence on x86 and ARM, but executes as 1 more uop on x86. Seems unlikely to harm performance much, if at all. https://rust.godbolt.org/z/q3zMxEc3T.

The added tests in `smoke.rs` fail with the old conversion and succeed with the new conversion.