### PR TITLE
Make `Rng::with_seed` const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl Rng {
     /// Creates a new random number generator with the initial seed.
     #[inline]
     #[must_use = "this creates a new instance of `Rng`; if you want to initialize the thread-local generator, use `fastrand::seed()` instead"]
-    pub fn with_seed(seed: u64) -> Self {
+    pub const fn with_seed(seed: u64) -> Self {
         Rng(seed)
     }
 


### PR DESCRIPTION
This is trivially possible here, enables `Rng` construction in const contexts, and I can't think of any downsides.