### PR TITLE
Rapidhash RNG algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ alloc = []
 std = ["alloc"]
 js = ["std", "getrandom"]
 
+[dependencies.rapidhash]
+version = "4"
+default-features = false
+
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"], optional = true }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://docs.rs/fastrand)
 
 A simple and fast random number generator.
 
-The implementation uses [Wyrand](https://github.com/wangyi-fudan/wyhash), a simple and fast
+The implementation uses [rapidhash](https://github.com/hoxxep/rapidhash), a simple and fast
 generator but **not** cryptographically secure.
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ impl Rng {
     /// Generates a random `u64`.
     #[inline]
     fn gen_u64(&mut self) -> u64 {
-        rapidhash::rng::rapidrng_fast(&mut self.0)
+        rapidhash::rng::rapidrng_fast_not_portable(&mut self.0)
     }
 
     /// Generates a random `u128`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A simple and fast random number generator.
 //!
-//! The implementation uses [Wyrand](https://github.com/wangyi-fudan/wyhash), a simple and fast
+//! The implementation uses [rapidhash](https://github.com/hoxxep/rapidhash), a simple and fast
 //! generator but **not** cryptographically secure.
 //!
 //! # Examples
@@ -147,15 +147,7 @@ impl Rng {
     /// Generates a random `u64`.
     #[inline]
     fn gen_u64(&mut self) -> u64 {
-        // Constants for WyRand taken from: https://github.com/wangyi-fudan/wyhash/blob/master/wyhash.h#L151
-        // Updated for the final v4.2 implementation with improved constants for better entropy output.
-        const WY_CONST_0: u64 = 0x2d35_8dcc_aa6c_78a5;
-        const WY_CONST_1: u64 = 0x8bb8_4b93_962e_acc9;
-
-        let s = self.0.wrapping_add(WY_CONST_0);
-        self.0 = s;
-        let t = u128::from(s) * u128::from(s ^ WY_CONST_1);
-        (t as u64) ^ (t >> 64) as u64
+        rapidhash::rng::rapidrng_fast(&mut self.0)
     }
 
     /// Generates a random `u128`.


### PR DESCRIPTION
Replaces the current [wyhash](https://github.com/wangyi-fudan/wyhash) RNG algorithm with [rapidhash](https://github.com/Nicoshev/rapidhash). 

The last commit can be dropped if the output (given the same seed) should be stable across different platforms.

closes #69 