### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 2.4.0
+
+- Bump MSRV to 1.63. (#104)
+- Improve quality of f32/f64 generation. (#103)
+- Add `f{32,64}_inclusive` and `Rng::f{32,64}_inclusive`. (#103)
+- Make `Rng::with_seed` const. (#107)
+- Update `getrandom` to 0.3. (#104)
+
 # Version 2.3.0
 
 - Accept `IntoIterator` in `choose_multiple` functions instead of just `Iterator`. (#92)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fastrand"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.3.0"
+version = "2.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.63"


### PR DESCRIPTION
Changes:

- Bump MSRV to 1.63. (#104)
- Improve quality of f32/f64 generation. (#103)
- Add `f{32,64}_inclusive` and `Rng::f{32,64}_inclusive`. (#103)
- Make `Rng::with_seed` const. (#107)
- Update `getrandom` to 0.3. (#104)
