### PR TITLE
chore: fix grammatical errors in documentation comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let i = fastrand::usize(..v.len());
 let elem = v[i];
 ```
 
-Sample values from an array with `O(n)` complexity (`n` is the length of array):
+Sample values from an array with `O(n)` complexity (`n` is the length of the array):
 
 ```rust
 fastrand::choose_multiple([1, 4, 5], 2);
@@ -79,7 +79,7 @@ generator:
 ```rust
 use std::iter::repeat_with;
 
-let rng = fastrand::Rng::new();
+let mut rng = fastrand::Rng::new();
 let mut bytes: Vec<u8> = repeat_with(|| rng.u8(..)).take(10_000).collect();
 ```
 

--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -85,13 +85,13 @@ pub fn bool() -> bool {
     with_rng(|r| r.bool())
 }
 
-/// Generates a random `char` in ranges a-z and A-Z.
+/// Generates a random `char` in range a-z and A-Z.
 #[inline]
 pub fn alphabetic() -> char {
     with_rng(|r| r.alphabetic())
 }
 
-/// Generates a random `char` in ranges a-z, A-Z and 0-9.
+/// Generates a random `char` in range a-z, A-Z and 0-9.
 #[inline]
 pub fn alphanumeric() -> char {
     with_rng(|r| r.alphanumeric())
@@ -125,7 +125,7 @@ where
 
 /// Generates a random digit in the given `base`.
 ///
-/// Digits are represented by `char`s in ranges 0-9 and a-z.
+/// Digits are represented by `char`s in range 0-9 and a-z.
 ///
 /// Panics if the base is zero or greater than 36.
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! let elem = v[i];
 //! ```
 //!
-//! Sample values from an array with `O(n)` complexity (`n` is the length of array):
+//! Sample values from an array with `O(n)` complexity (`n` is the length of the array):
 //!
 //! ```
 //! fastrand::choose_multiple([1, 4, 5], 2);
@@ -322,14 +322,14 @@ impl Rng {
         Rng::with_seed(self.gen_u64())
     }
 
-    /// Generates a random `char` in ranges a-z and A-Z.
+    /// Generates a random `char` in range a-z and A-Z.
     #[inline]
     pub fn alphabetic(&mut self) -> char {
         const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
         *self.choice(CHARS).unwrap() as char
     }
 
-    /// Generates a random `char` in ranges a-z, A-Z and 0-9.
+    /// Generates a random `char` in range a-z, A-Z and 0-9.
     #[inline]
     pub fn alphanumeric(&mut self) -> char {
         const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -344,7 +344,7 @@ impl Rng {
 
     /// Generates a random digit in the given `base`.
     ///
-    /// Digits are represented by `char`s in ranges 0-9 and a-z.
+    /// Digits are represented by `char`s in range 0-9 and a-z.
     ///
     /// Panics if the base is zero or greater than 36.
     #[inline]


### PR DESCRIPTION
Corrected plural "ranges" to singular "range" in documentation comments and fixed other minor grammatical issues across the codebase to improve documentation quality and consistency.