### PR TITLE
Change WyRand to a Marsaglia multiply-with-carry with 192 bits of state

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native", "-A", "non-camel-case-types", "-A", "non-upper-case-globals", "-A", "non_snake_case"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["-C", "target-cpu=native", "-A", "non-camel-case-types", "-A", "non-upper-case-globals", "-A", "non_snake_case"]
+rustflags = ["-C", "target-cpu=native"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.4.2
+
+- Replaced WyRand with a Marsaglia multiply-with-carry generator with 192 bits
+  of state.
+
 # Version 2.4.1
 
 - Fix build failure with `js` feature. (#125)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Version 3.0.0
 
 - Replaced WyRand with a Marsaglia multiply-with-carry generator with 192 bits
-  of state.
+  of state. (#129)
+- Removed `get_seed` and `Rng::get_seed`. (#129)
 
 # Version 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 2.4.2
+# Version 3.0.0
 
 - Replaced WyRand with a Marsaglia multiply-with-carry generator with 192 bits
   of state.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.63"
 description = "A simple and fast random number generator"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/fastrand"
-keywords = ["simple", "fast", "rand", "random", "wyrand"]
+keywords = ["simple", "fast", "rand", "random", "MWC"]
 categories = ["algorithms"]
 exclude = ["/.*"]
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 # fastrand
 
-[![Build](https://github.com/smol-rs/fastrand/actions/workflows/ci.yml/badge.svg)](
-https://github.com/smol-rs/fastrand/actions)
-[![License](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](
-https://github.com/smol-rs/fastrand)
-[![Cargo](https://img.shields.io/crates/v/fastrand.svg)](
-https://crates.io/crates/fastrand)
-[![Documentation](https://docs.rs/fastrand/badge.svg)](
-https://docs.rs/fastrand)
+[![Build](https://github.com/smol-rs/fastrand/actions/workflows/ci.yml/badge.svg)](https://github.com/smol-rs/fastrand/actions)
+[![License](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](https://github.com/smol-rs/fastrand)
+[![Cargo](https://img.shields.io/crates/v/fastrand.svg)](https://crates.io/crates/fastrand)
+[![Documentation](https://docs.rs/fastrand/badge.svg)](https://docs.rs/fastrand)
 
 A simple and fast random number generator.
 
-The implementation uses [Wyrand](https://github.com/wangyi-fudan/wyhash), a simple and fast
-generator but **not** cryptographically secure.
+The implementation uses a [Marsaglia multiply-with-carry generator with 192 bits
+of state](https://prng.di.unimi.it/MWC192.c), a simple and fast generator but
+**not** cryptographically secure.
 
 ## Examples
 
@@ -98,8 +95,8 @@ This crate aims to expose a core set of useful randomness primitives. For more n
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/mit)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/mit)
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # fastrand
 
-[![Build](https://github.com/smol-rs/fastrand/actions/workflows/ci.yml/badge.svg)](https://github.com/smol-rs/fastrand/actions)
-[![License](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](https://github.com/smol-rs/fastrand)
-[![Cargo](https://img.shields.io/crates/v/fastrand.svg)](https://crates.io/crates/fastrand)
-[![Documentation](https://docs.rs/fastrand/badge.svg)](https://docs.rs/fastrand)
+[![Build](https://github.com/smol-rs/fastrand/actions/workflows/ci.yml/badge.svg)](
+https://github.com/smol-rs/fastrand/actions)
+[![License](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](
+https://github.com/smol-rs/fastrand)
+[![Cargo](https://img.shields.io/crates/v/fastrand.svg)](
+https://crates.io/crates/fastrand)
+[![Documentation](https://docs.rs/fastrand/badge.svg)](
+https://docs.rs/fastrand)
 
 A simple and fast random number generator.
 
@@ -95,8 +99,8 @@ This crate aims to expose a core set of useful randomness primitives. For more n
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/mit)
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/mit)
 
 at your option.
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -91,7 +91,7 @@ fn u64_fastrand(b: &mut Bencher) {
     let mut rng = fastrand::Rng::new();
     b.iter(|| {
         for _ in 0..10_000 {
-            black_box(rng.gen_u64());
+            black_box(rng.u64(..));
         }
     })
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,6 +2,8 @@
 
 extern crate test;
 
+use std::hint::black_box;
+
 use rand::prelude::*;
 use test::Bencher;
 use wyhash::WyRng;
@@ -78,11 +80,9 @@ fn u32_fastrand(b: &mut Bencher) {
 fn u64_wyhash(b: &mut Bencher) {
     let mut rng = WyRng::from_rng(&mut rand::rng());
     b.iter(|| {
-        let mut sum = 0u64;
         for _ in 0..10_000 {
-            sum = sum.wrapping_add(rng.random::<u64>());
+            black_box(rng.random::<u64>());
         }
-        sum
     })
 }
 
@@ -90,11 +90,9 @@ fn u64_wyhash(b: &mut Bencher) {
 fn u64_fastrand(b: &mut Bencher) {
     let mut rng = fastrand::Rng::new();
     b.iter(|| {
-        let mut sum = 0u64;
         for _ in 0..10_000 {
-            sum = sum.wrapping_add(rng.gen_u64());
+            black_box(rng.gen_u64());
         }
-        sum
     })
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -75,6 +75,30 @@ fn u32_fastrand(b: &mut Bencher) {
 }
 
 #[bench]
+fn u64_wyhash(b: &mut Bencher) {
+    let mut rng = WyRng::from_rng(&mut rand::rng());
+    b.iter(|| {
+        let mut sum = 0u64;
+        for _ in 0..10_000 {
+            sum = sum.wrapping_add(rng.random::<u64>());
+        }
+        sum
+    })
+}
+
+#[bench]
+fn u64_fastrand(b: &mut Bencher) {
+    let mut rng = fastrand::Rng::new();
+    b.iter(|| {
+        let mut sum = 0u64;
+        for _ in 0..10_000 {
+            sum = sum.wrapping_add(rng.gen_u64());
+        }
+        sum
+    })
+}
+
+#[bench]
 fn f32_fastrand(b: &mut Bencher) {
     let mut rng = fastrand::Rng::new();
     b.iter(|| {

--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -35,7 +35,7 @@ std::thread_local! {
 #[inline]
 fn with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> R {
     RNG.with(|rng| {
-        let current = rng.replace(Rng::with_seed(0));
+        let current = rng.replace(Rng { c: 1, x: 0, y: 0 });
 
         let mut restore = RestoreOnDrop { rng, current };
 
@@ -47,7 +47,7 @@ fn with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> R {
 #[inline]
 fn try_with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> Result<R, std::thread::AccessError> {
     RNG.try_with(|rng| {
-        let current = rng.replace(Rng::with_seed(0));
+        let current = rng.replace(Rng { c: 1, x: 0, y: 0 });
 
         let mut restore = RestoreOnDrop { rng, current };
 

--- a/src/global_rng.rs
+++ b/src/global_rng.rs
@@ -28,14 +28,14 @@ impl Rng {
 }
 
 std::thread_local! {
-    static RNG: Cell<Rng> = Cell::new(Rng(random_seed().unwrap_or(DEFAULT_RNG_SEED)));
+    static RNG: Cell<Rng> = Cell::new(Rng::with_seed(random_seed().unwrap_or(DEFAULT_RNG_SEED)));
 }
 
 /// Run an operation with the current thread-local generator.
 #[inline]
 fn with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> R {
     RNG.with(|rng| {
-        let current = rng.replace(Rng(0));
+        let current = rng.replace(Rng::with_seed(0));
 
         let mut restore = RestoreOnDrop { rng, current };
 
@@ -47,7 +47,7 @@ fn with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> R {
 #[inline]
 fn try_with_rng<R>(f: impl FnOnce(&mut Rng) -> R) -> Result<R, std::thread::AccessError> {
     RNG.try_with(|rng| {
-        let current = rng.replace(Rng(0));
+        let current = rng.replace(Rng::with_seed(0));
 
         let mut restore = RestoreOnDrop { rng, current };
 
@@ -63,7 +63,7 @@ struct RestoreOnDrop<'a> {
 
 impl Drop for RestoreOnDrop<'_> {
     fn drop(&mut self) {
-        self.rng.set(Rng(self.current.0));
+        self.rng.set(self.current.clone());
     }
 }
 
@@ -71,12 +71,6 @@ impl Drop for RestoreOnDrop<'_> {
 #[inline]
 pub fn seed(seed: u64) {
     with_rng(|r| r.seed(seed));
-}
-
-/// Gives back **current** seed that is being held by the thread-local generator.
-#[inline]
-pub fn get_seed() -> u64 {
-    with_rng(|r| r.get_seed())
 }
 
 /// Generates a random `bool`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,12 +128,20 @@ pub use global_rng::*;
 
 /// A random number generator.
 #[derive(Debug, PartialEq, Eq)]
-pub struct Rng(u64);
+pub struct Rng {
+    x: u64,
+    y: u64,
+    c: u64,
+}
 
 impl Clone for Rng {
     /// Clones the generator by creating a new generator with the same seed.
     fn clone(&self) -> Rng {
-        Rng::with_seed(self.0)
+        Rng {
+            x: self.x,
+            y: self.y,
+            c: self.c,
+        }
     }
 }
 
@@ -147,15 +155,16 @@ impl Rng {
     /// Generates a random `u64`.
     #[inline]
     fn gen_u64(&mut self) -> u64 {
-        // Constants for WyRand taken from: https://github.com/wangyi-fudan/wyhash/blob/master/wyhash.h#L151
-        // Updated for the final v4.2 implementation with improved constants for better entropy output.
-        const WY_CONST_0: u64 = 0x2d35_8dcc_aa6c_78a5;
-        const WY_CONST_1: u64 = 0x8bb8_4b93_962e_acc9;
+        const MWC_A2: u64 = 0xffa04e67b3c95d86;
+        let result = self.y;
 
-        let s = self.0.wrapping_add(WY_CONST_0);
-        self.0 = s;
-        let t = u128::from(s) * u128::from(s ^ WY_CONST_1);
-        (t as u64) ^ (t >> 64) as u64
+        let t = (MWC_A2 as u128)
+            .wrapping_mul(self.x as u128)
+            .wrapping_add(self.c as u128);
+        self.x = self.y;
+        self.y = t as u64;
+        self.c = (t >> 64) as u64;
+        result
     }
 
     /// Generates a random `u128`.
@@ -290,7 +299,11 @@ impl Rng {
     #[inline]
     #[must_use = "this creates a new instance of `Rng`; if you want to initialize the thread-local generator, use `fastrand::seed()` instead"]
     pub const fn with_seed(seed: u64) -> Self {
-        Rng(seed)
+        Rng {
+            x: seed,
+            y: seed,
+            c: 1,
+        }
     }
 
     /// Clones the generator by deterministically deriving a new generator based on the initial
@@ -539,13 +552,8 @@ impl Rng {
     /// Initializes this generator with the given seed.
     #[inline]
     pub fn seed(&mut self, seed: u64) {
-        self.0 = seed;
-    }
-
-    /// Gives back **current** seed that is being held by this generator.
-    #[inline]
-    pub fn get_seed(&self) -> u64 {
-        self.0
+        self.c = 1;
+        self.x = seed;
     }
 
     /// Choose an item from an iterator at random.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ pub struct Rng {
 }
 
 impl Clone for Rng {
-    /// Clones the generator by creating a new generator with the same seed.
+    /// Clones the generator, copying its current state.
     fn clone(&self) -> Rng {
         Rng {
             x: self.x,
@@ -156,7 +156,7 @@ impl Rng {
 
     /// Generates a random `u64`.
     #[inline]
-    pub fn gen_u64(&mut self) -> u64 {
+    fn gen_u64(&mut self) -> u64 {
         // Constant from https://prng.di.unimi.it/MWC192.c
         const MWC_A2: u64 = 0xffa04e67b3c95d86;
         let result = self.y;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ impl Rng {
 
     /// Generates a random `u64`.
     #[inline]
-    fn gen_u64(&mut self) -> u64 {
+    pub fn gen_u64(&mut self) -> u64 {
         const MWC_A2: u64 = 0xffa04e67b3c95d86;
         let result = self.y;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,23 +297,27 @@ macro_rules! rng_integer {
     };
 }
 
-impl Rng {
-    const fn remix_seed(seed: u64) -> u64 {
-        seed.wrapping_mul(0xd1342543de82ef95)
-            .wrapping_add(0x9e3779b97f4a7c15)
-    }
+/// The [SplitMix](https://dl.acm.org/doi/10.1145/2714064.2660195)
+/// finalizing mixer (used only for seeding).
+const fn split_mix64(z: u64) -> u64 {
+    let z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+    let z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
+    z ^ (z >> 31)
+}
 
+impl Rng {
     /// Creates a new random number generator with the initial seed.
     #[inline]
     #[must_use = "this creates a new instance of `Rng`; if you want to initialize the thread-local generator, use `fastrand::seed()` instead"]
     pub const fn with_seed(seed: u64) -> Self {
-        // Remixes minimally the seed since the first output is y
-        let remixed_seed = Self::remix_seed(seed);
-        Rng {
-            x: remixed_seed,
-            y: remixed_seed,
-            c: 1,
-        }
+        // Advance the state by the SplitMix increment before mixing, and take
+        // two successive outputs.
+        const INCREMENT: u64 = 0x9e3779b97f4a7c15;
+        let s = seed.wrapping_add(INCREMENT);
+        let x = split_mix64(s);
+        let s = s.wrapping_add(INCREMENT);
+        let y = split_mix64(s);
+        Rng { x, y, c: 1 }
     }
 
     /// Clones the generator by deterministically deriving a new generator based on the initial
@@ -562,11 +566,7 @@ impl Rng {
     /// Initializes this generator with the given seed.
     #[inline]
     pub fn seed(&mut self, seed: u64) {
-        // Remix minimially the seed since the first output is y
-        let remixed_seed = Self::remix_seed(seed);
-        self.c = 1;
-        self.x = remixed_seed;
-        self.y = remixed_seed;
+        *self = Self::with_seed(seed);
     }
 
     /// Choose an item from an iterator at random.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,6 +554,7 @@ impl Rng {
     pub fn seed(&mut self, seed: u64) {
         self.c = 1;
         self.x = seed;
+        self.y = seed;
     }
 
     /// Choose an item from an iterator at random.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 //! A simple and fast random number generator.
 //!
-//! The implementation uses [Wyrand](https://github.com/wangyi-fudan/wyhash), a simple and fast
-//! generator but **not** cryptographically secure.
+//! The implementation uses [Marsaglia multiply-with-carry generator with 192
+//! bits of state](https://prng.di.unimi.it/MWC192.c), a simple and fast
+//! generator but **not** cryptographically secure. The generator has a period
+//! of ≈2¹⁹¹.
 //!
 //! # Examples
 //!
@@ -155,6 +157,7 @@ impl Rng {
     /// Generates a random `u64`.
     #[inline]
     pub fn gen_u64(&mut self) -> u64 {
+        // Constant from https://prng.di.unimi.it/MWC192.c
         const MWC_A2: u64 = 0xffa04e67b3c95d86;
         let result = self.y;
 
@@ -295,13 +298,20 @@ macro_rules! rng_integer {
 }
 
 impl Rng {
+    const fn remix_seed(seed: u64) -> u64 {
+        seed.wrapping_mul(0xd1342543de82ef95)
+            .wrapping_add(0x9e3779b97f4a7c15)
+    }
+
     /// Creates a new random number generator with the initial seed.
     #[inline]
     #[must_use = "this creates a new instance of `Rng`; if you want to initialize the thread-local generator, use `fastrand::seed()` instead"]
     pub const fn with_seed(seed: u64) -> Self {
+        // Remixes minimally the seed since the first output is y
+        let remixed_seed = Self::remix_seed(seed);
         Rng {
-            x: seed,
-            y: seed,
+            x: remixed_seed,
+            y: remixed_seed,
             c: 1,
         }
     }
@@ -393,7 +403,7 @@ impl Rng {
         // There is still some remaining bias in the int-to-float conversion, because
         // nonzero numbers <=2^(-64) are never generated, even though they are
         // expressible in f32. However, at this point the bias in int-to-float conversion
-        // is no larger than the bias in the underlying WyRand generator: since it only
+        // is no larger than the bias in the underlying generator: since it only
         // has a 64-bit state, it necessarily already have biases of at least 2^(-64)
         // probability.
         //
@@ -552,9 +562,11 @@ impl Rng {
     /// Initializes this generator with the given seed.
     #[inline]
     pub fn seed(&mut self, seed: u64) {
+        // Remix minimially the seed since the first output is y
+        let remixed_seed = Self::remix_seed(seed);
         self.c = 1;
-        self.x = seed;
-        self.y = seed;
+        self.x = remixed_seed;
+        self.y = remixed_seed;
     }
 
     /// Choose an item from an iterator at random.
@@ -592,7 +604,7 @@ impl Rng {
     #[inline]
     pub fn fill(&mut self, slice: &mut [u8]) {
         // We fill the slice by chunks of 8 bytes, or one block of
-        // WyRand output per new state.
+        // output per new state.
         let mut chunks = slice.chunks_exact_mut(core::mem::size_of::<u64>());
         for chunk in chunks.by_ref() {
             let n = self.gen_u64().to_ne_bytes();


### PR DESCRIPTION
There are a few caveats:

- `get_seed` is not longer available. It makes sense only for a counter—any other generator does not give you the seed, given the internal state. So in theory you should bump this to 3.0.0.

- There is a stale comment on the generation of `f32` saying that the generator has 64 bits of state, but I don't know how you might want to change it.

You might also want to reconsider the way you are generating floats. Java, Rust, C++, etc., all follow the standard practice of extracting 53 (f64) or 24 (f32) bits and multiply by 1/2^53 (1/^24). There's some explanation [here](https://prng.di.unimi.it/#remarks).

The problem with your approach is that you will be generating very occasionally values such as 2^-63, but at the same time you will be generating (for an f32) 2^40 copies of 1/2. This happens because the resolution of floats is very good close to zero, but not so good as numbers gets larger.

While it is desirable to have very small number, it basically makes the generation non-uniform, as some floats gets generated much more often than others. It's a judgement call, in any case.


Closes #128