### PR TITLE
Bump getrandom to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,16 @@ std = ["alloc"]
 js = ["std", "getrandom"]
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.3.4", features = ["wasm_js"], optional = true }
+getrandom = { version = "0.4", features = ["wasm_js"], optional = true }
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
-getrandom = { version = "0.3.4", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [dev-dependencies]
-rand = "0.9"
+rand = "0.10"
 wyhash = "0.6"
-getrandom = "0.3.4"
+getrandom = "0.4"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,11 +4,37 @@ extern crate test;
 
 use rand::prelude::*;
 use test::Bencher;
-use wyhash::WyRng;
+
+/// Exposes wyhash's RNG through the rand traits
+struct WyRng(u64);
+
+impl rand::TryRng for WyRng {
+    type Error = std::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(wyhash::wyrng(&mut self.0) as u32)
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(wyhash::wyrng(&mut self.0))
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        for chunk in dst.chunks_mut(8) {
+            let bytes = wyhash::wyrng(&mut self.0).to_le_bytes();
+            chunk.copy_from_slice(&bytes[..chunk.len()]);
+        }
+        Ok(())
+    }
+}
+
+fn wyrng() -> WyRng {
+    WyRng(rand::random())
+}
 
 #[bench]
 fn shuffle_wyhash(b: &mut Bencher) {
-    let mut rng = WyRng::from_rng(&mut rand::rng());
+    let mut rng = wyrng();
     let mut x = (0..100).collect::<Vec<usize>>();
     b.iter(|| {
         x.shuffle(&mut rng);
@@ -28,7 +54,7 @@ fn shuffle_fastrand(b: &mut Bencher) {
 
 #[bench]
 fn u8_wyhash(b: &mut Bencher) {
-    let mut rng = WyRng::from_rng(&mut rand::rng());
+    let mut rng = wyrng();
     b.iter(|| {
         let mut sum = 0u8;
         for _ in 0..10_000 {
@@ -52,7 +78,7 @@ fn u8_fastrand(b: &mut Bencher) {
 
 #[bench]
 fn u32_wyhash(b: &mut Bencher) {
-    let mut rng = WyRng::from_rng(&mut rand::rng());
+    let mut rng = wyrng();
     b.iter(|| {
         let mut sum = 0u32;
         for _ in 0..10_000 {


### PR DESCRIPTION
Similar to https://github.com/smol-rs/fastrand/pull/122 except CI should be happy 🤞 

getrandom 0.4 adds platform support for wasm64 which is what I'm interested

Closes https://github.com/smol-rs/fastrand/pull/120
Closes https://github.com/smol-rs/fastrand/pull/122